### PR TITLE
remove access level from nimbus edu

### DIFF
--- a/app/NimbusEdu/NimbusEdu.php
+++ b/app/NimbusEdu/NimbusEdu.php
@@ -55,8 +55,6 @@ class NimbusEdu
 
       $user->fill($data);
 
-      $user->access_level_id = 2;
-
       $user->save();
 
       switch($user_type){


### PR DESCRIPTION
we dont need access level any more since we run roles through permissions